### PR TITLE
Remove the custom change of the nstab-main text content

### DIFF
--- a/Common.js
+++ b/Common.js
@@ -174,16 +174,6 @@ $(function() {
 //    logoLink.href = '/wiki/Име на страницата'; // <-- поставете името на страницата между апострофите, но запазете /wiki/ отпред
 //});
 
-// Преименуване на етикета "Статия" за началната страница
-if (mw.config.get('wgIsMainPage') || mw.config.get('wgPageName') == 'Беседа:Начална_страница') {
-    $(function () {
-        var nstab = document.getElementById('ca-nstab-main');
-        if (nstab && mw.config.get('wgUserLanguage')=='bg') {
-            while (nstab.firstChild) { nstab = nstab.firstChild; }
-            nstab.nodeValue = 'Начална страница';
-        }
-    });
-}
 
 /**
  * Script pour alterner entre plusieurs cartes de géolocalisation


### PR DESCRIPTION
This custom change is not needed anymore as this is now done by MediaWiki itself.

see https://bg.wikipedia.org/w/index.php?oldid=10317258#Преименуване_на_етикета_"Статия"_за_началната_страница_–_ненужно