### PR TITLE
Remove CSS related to old NavFrame/NavContent.

### DIFF
--- a/Common.css
+++ b/Common.css
@@ -1304,11 +1304,6 @@ pre.source-lua {
 /* Géolocalisation dynamique */
 /* Стилове за Шаблон:ПК група */
 
-.NavContent .img_toggle {
-  zoom: 1; /* be kind to IE7 */
-  clear: both; /* be kind to IE7 */
-}
-
 .img_toggle,
 .img_toggle * {
  margin: 0 auto !important;


### PR DESCRIPTION
The old NavFrame functionality is not used anymore on bg.wikipedia so there is no need for its classes.